### PR TITLE
add permissions for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add contents: write permission for GITHUB_TOKEN in deploy GitHub Actions workflow